### PR TITLE
이상화 / 1기 1주차 / 1문제

### DIFF
--- a/coding-test-java.iml
+++ b/coding-test-java.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/kimyeonsup" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/sanghwa" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/sanghwa/AGS/Festival.java
+++ b/sanghwa/AGS/Festival.java
@@ -1,0 +1,55 @@
+package AGS;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Festival {
+
+    public static void setCostArray(int[] cost, int dayNum, BufferedReader buffer) throws IOException {
+        StringTokenizer stringToken = new StringTokenizer(buffer.readLine());
+        for (int i = 0; i < dayNum; ++i)
+            cost[i] = Integer.parseInt(stringToken.nextToken());
+    }
+
+    public static double getAverage(int[] cost, int start, int len) {
+        double sum = 0;
+        for (int i = start; i < start + len; ++i)
+            sum += cost[i];
+        return sum / (len);
+    }
+
+    public static double getMinCost(int[] cost, int dayNum, int teamNum) {
+        double minAverage = 100.0;
+        double average;
+        int len = teamNum;
+
+        while (len <= dayNum) {
+            for (int i = 0; i + len <= dayNum; ++i) {
+                average = getAverage(cost, i, len);
+                minAverage = Math.min(minAverage, average);
+            }
+            len++;
+        }
+        return  minAverage;
+    }
+
+    public static void main(String[] args) throws IOException {
+        int caseNum, dayNum, teamNum;
+        BufferedReader buffer = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer stringToken = new StringTokenizer(buffer.readLine());
+
+        caseNum = Integer.parseInt(stringToken.nextToken());
+
+        for (int i = 0; i < caseNum; ++i) {
+            stringToken = new StringTokenizer(buffer.readLine());
+            dayNum = Integer.parseInt(stringToken.nextToken());
+            teamNum = Integer.parseInt(stringToken.nextToken());
+            int[] cost = new int[dayNum];
+            setCostArray(cost, dayNum, buffer);
+            double min = getMinCost(cost, dayNum, teamNum);
+            System.out.printf("%.11f\n", min);
+        }
+    }
+}

--- a/sanghwa/README.md
+++ b/sanghwa/README.md
@@ -1,2 +1,2 @@
-Github Id : idealflower-k
-name : Lee sanghwa
+- Github Id : idealflower-k
+- name : Lee sanghwa

--- a/sanghwa/README.md
+++ b/sanghwa/README.md
@@ -1,0 +1,2 @@
+Github Id : idealflower-k
+name : Lee sanghwa


### PR DESCRIPTION
## 문제명 : ``` 록 페스티벌 ```
> 시간 복잡도 :  , 공간 복잡도 : 

### 1. 풀이 과정
```
1. 최소 연속 대여일 = 이미 섭외된 팀 수
2. 최대 연속 대여일 = 대여 가능 일 수
3. 위 값들을 기준으로 "최소 연속 대여일" 부터 "최대 연속 대여일" 만큼 배열의 크기를 증가
4. "연속 대여일 배열"의 크기마다 "대여비용 배열"에 인덱스 값으로 합을 구하여 평균값 계산(윈도우 슬라이딩 기법 이라고 함)
5. "최소 평균값"을 갱신하며 최종 "최소 평균 값" 출력
```
### 2. 아쉬웠던 점
```
1. 매번 모든 값을 더해서 합을 구하는게 아니라 처음 인덱스 값을 빼고 다음 추가 될 인덱스의 값을 더하는 식으로 불필요한 더하기 연산을 줄일 수 있었음
2. BufferedReader를 사용했지만 JVM에서 모든 리소스를 정리해주지 않기 때문에 close()함수를 사용을 필수로 하는게 좋음
3. 2번의 다른 해결방법으로 try-with-resources 구문이 존재
4. Java에 아직 적응 되지않아 간단한 코드 작성에 너무 많은 시간이 걸림
```