### PR TITLE
최동현 / 1기 1주차 / 1문제 / 오프라인

### DIFF
--- a/choidonghyeon/java/OFFLINE/BOJ/CandyGame.java
+++ b/choidonghyeon/java/OFFLINE/BOJ/CandyGame.java
@@ -1,0 +1,97 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class CandyGame {
+    static char[][] board;
+    static int n;
+    static int answer = 1;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+        board = new char[n][n];
+
+        for (int i = 0; i < n; i++) {
+            String inputLine = br.readLine();
+            for (int j = 0; j < n; j++) {
+                board[i][j] = inputLine.charAt(j);
+            }
+        }
+
+        for (int i = 0; i < n; i++) {
+            findLongestInRow(i);
+            findLongestInColumn(i);  //swap 하지 않았을때의 가장 긴 연속 부분 찾기
+
+            for (int x = 0; x < n - 1; x++) {
+                if (!isSameColor(board[i][x], board[i][x + 1])) { //인접한 두 원소의 색이 다르며, 같은 행일때
+                    swap(i, x, i, x + 1);
+                    calculateInSameRow(i, x, x + 1);
+                    swap(i, x, i, x + 1);  //원상 복구
+                }
+            }
+
+            for (int y = 0; y < n - 1; y++) {
+                if (!isSameColor(board[y][i], board[y + 1][i])) { //인접한 두 원소의 색이 다르며, 같은 열일때
+                    swap(y, i, y + 1, i);
+                    calculateInSameColumn(i, y, y + 1);
+                    swap(y, i, y + 1, i);
+                }
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    public static void calculateInSameRow(int y, int x1, int x2) { //인접한 두 원소가 같은 행인 경우
+        findLongestInColumn(x1);
+        findLongestInColumn(x2);
+        findLongestInRow(y);
+    }
+
+    public static void calculateInSameColumn(int x, int y1, int y2) { //인접한 두 원소가 같은 열인 경우
+        //열 탐색
+        findLongestInColumn(x);
+        findLongestInRow(y1);
+        findLongestInRow(y2);
+    }
+
+    public static void findLongestInColumn(int x) { //특정 열에서 가장 긴 연속 부분 찾는 메서드
+        int py = 1;
+        for (int i = 0; i < n - 1; i++) {
+            if (isSameColor(board[i][x], board[i + 1][x])) {
+                py++;
+            } else {
+                answer = Math.max(answer, py);
+                py = 1;
+            }
+        }
+        answer = Math.max(answer, py); //반복문이 끝났을때도 다시 갱신.
+
+    }
+
+    public static void findLongestInRow(int y) { //특정 행에서 가장 긴 연속 부분 찾는 메서드
+        int px = 1;
+        for (int i = 0; i < n - 1; i++) {
+            if (isSameColor(board[y][i], board[y][i + 1])) {
+                px++;
+            } else {
+                answer = Math.max(answer, px);
+                px = 1;
+            }
+        }
+        answer = Math.max(answer, px);
+    }
+
+    public static boolean isSameColor(char e1, char e2) {
+        return e1 == e2;
+    }
+
+    public static void swap(int y1, int x1, int y2, int x2) {
+        char cmp;
+        cmp = board[y1][x1];
+        board[y1][x1] = board[y2][x2];
+        board[y2][x2] = cmp;
+    }
+}


### PR DESCRIPTION
## [오프라인] 사탕게임 - BOJ 3085번
>시간 복잡도 O(N**3) 예상, 공간 복잡도
>
>실행시간 : 92ms `java 8`
>
>페어 프로그래밍 : @yongjun-hong @goodchoi

### 풀이
처음에 문제를 접근할 때 `dfs` 혹은 `dp`를 의심했지만 n 의 최대 범위가 50임을 고려하여
완전 탐색을 시도하게 되었습니다.

이 문제는 크게 두 개의 하위 문제로 구분 할 수 있습니다.
1. 색이 다른 인접한 두칸을 고르고 교환하는 문제
2. 같은 색으로 이루어진 가장 긴 연속 부분을 고르는 문제

1번의 하위 문제같은 경우는 여러 방법이 있을 수 있으나 어떤 방법을 사용하던 크게 차이는 없을 것 같습니다.
저희는 같은 행과 같은 열을 확인 하는 방법으로 나누었습니다.

2번 하위문제를 고려할 때는 완전 탐색으로 테이블의 모든 행과 열을 대상으로 가장  
긴 연속 부분을 탐색할 것 인가에 대해 고민했지만 문제의 조건을 잘보면 총 3번의 탐색만으로도
충분하다는 것을 알 수 있습니다.

<img src="https://github.com/coding-test-java/problems/assets/105799662/8c250ffb-1d1d-46a8-bee5-65fd156f3c5e" width="150">

빨간색 네모의 두칸을 교환한 상황이라고 가정했을때, 영향이 미치는 것은 초록색의 행과 열이며, 나머지 행과 열은 아무런 영향을 받지 않는다는 것을 알 수 있습니다.
> 물론 인접한 두 칸이 같은 열에 있을때는 사진과 달리 2개의 행과 1개의 열을 탐색해합니다.

> 모든 행과 열을 탐색한다면 O(N**2)이지만 3개의 행과열을 탐색함으로써 O(N)으로 줄일 수 있었습니다.


또한 이렇게만 탐색하면 모든 반복문이 끝나도 탐색 되지 않는 행과 열이 있기 때문에 이부분도 [반복문 안에 따로 처리해](https://github.com/coding-test-java/problems/pull/20/files#diff-f979e0b6a91ffb4f10e35a4c0e164665ae53adbe81b8a800e07b214082dbeddaR24)두었습니다.


## 페어 프로그래밍 후기
아무래도 혼자 알고리즘 풀때랑 가장 다른 점은 문제를 접근하는 과정부터 실제 코드로 작성하는 모든 과정들을 페어 상대방과 계속 의논하면서 진행 해나가야한다는 점이었습니다. 따라서 진행속도는 당연히 혼자 하는것보다 느리겠지만, 모든 생각들의 근거나 의도를 확실히 상대방에게 전달 하기위한 노력이 필요했습니다. 처음이라 서툴렀지만 앞으로 차차 적응해나간다면 알고리즘 문제 해결에 필요한 사고력 뿐만아니라 개발자로서 필요한 협업 능력까지 모두 향상 시킬수 있는 좋은 방법이라 생각 들었습니다.
모두 수고하셨습니다!













