### PR TITLE
김연섭 / 1기 2주차 / 3문제

### DIFF
--- a/kimyeonsup/algospot/BoardCover.java
+++ b/kimyeonsup/algospot/BoardCover.java
@@ -1,0 +1,109 @@
+package jmb;
+
+import static java.lang.Integer.parseInt;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/*
+3
+3 7
+#.....#
+#.....#
+##...##
+3 7
+#.....#
+#.....#
+##..###
+8 10
+##########
+#........#
+#........#
+#........#
+#........#
+#........#
+#........#
+##########
+* */
+
+public class BoardCover {
+
+    private static int[][] board;
+    private static int[][][] coverType = {
+            {{0, 0}, {1, 0} , {0, 1}},
+            {{0, 0}, {0, 1} , {1, 1}},
+            {{0, 0}, {1, 0} , {1, 1}},
+            {{0, 0}, {1, 0} , {1, -1}}
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        int testcase = parseInt(bf.readLine());
+
+        while (testcase-- > 0) {
+            StringTokenizer stringTokenizer = new StringTokenizer(bf.readLine());
+            int boardYSize = Integer.parseInt(stringTokenizer.nextToken());
+            int boardXSize = Integer.parseInt(stringTokenizer.nextToken());
+            board = new int[boardYSize][boardXSize];
+
+            for (int i = 0; i < boardYSize; i++) {
+                char[] boardCols = bf.readLine().toCharArray();
+                for (int j = 0; j < boardXSize; j++) {
+                    if (boardCols[j] == '#') {
+                        board[i][j] = 1;
+                    } else {
+                        board[i][j] = 0;
+                    }
+                }
+            }
+
+            System.out.println(cover());
+        }
+    }
+
+    private static int cover() {
+        int y = -1;
+        int x = -1;
+        for (int i = 0; i < board.length; i++) {
+            for (int j = 0; j < board[i].length; j++) {
+                if (board[i][j] == 0) {
+                    y = i;
+                    x = j;
+                    break;
+                }
+            }
+            if (y != -1) break;
+        }
+        if (y == -1) return 1;
+
+        int result = 0;
+        for (int type = 0; type < 4; type++) {
+            if (set(y, x, type, 1)) {
+                result += cover();
+            }
+            set(y, x, type, -1);
+        }
+        return result;
+    }
+
+    private static boolean set(int y, int x, int type, int set) {
+        boolean isTrue = true;
+
+        for (int i = 0; i < 3; i++) {
+            int coverY = y + coverType[type][i][0];
+            int coverX = x + coverType[type][i][1];
+            if(isRange(coverY, coverX)) {
+                isTrue = false;
+            } else if ((board[coverY][coverX] += set) > 1) {
+                isTrue = false;
+            }
+        }
+        return isTrue;
+    }
+
+    private static boolean isRange(int coverY, int coverX) {
+        return coverY < 0 || coverY >= board.length || coverX < 0 || coverX >= board[0].length;
+    }
+}

--- a/kimyeonsup/algospot/Sopung.java
+++ b/kimyeonsup/algospot/Sopung.java
@@ -1,0 +1,88 @@
+package jmb;
+
+import static java.lang.Integer.parseInt;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+public class Sopung {
+
+    private static List<Pair> pairs;
+    private static Set<Pair> isVisited;
+    private static int count;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        int testcase = parseInt(bf.readLine());
+
+        while (testcase-- > 0) {
+            StringTokenizer stringTokenizer = new StringTokenizer(bf.readLine());
+            int studentCount = parseInt(stringTokenizer.nextToken());
+            int pairCount = parseInt(stringTokenizer.nextToken());
+            count = 0;
+
+            stringTokenizer = new StringTokenizer(bf.readLine());
+            pairs = getPairs(stringTokenizer);
+            isVisited = new HashSet<>();
+            search(studentCount / 2, 0);
+
+            System.out.println(count);
+        }
+    }
+
+    private static void search(int length, int depth) {
+        if(length == isVisited.size()) {
+            count++;
+            return ;
+        }
+
+        for (int i = depth; i < pairs.size(); i++) {
+            Pair target = pairs.get(i);
+            if (isVisited.stream().noneMatch(pair -> pair.isDuplicate(target))) {
+                isVisited.add(target);
+                search(length, i + 1);
+                isVisited.remove(target);
+            }
+        }
+    }
+
+    private static List<Pair> getPairs(StringTokenizer stringTokenizer) {
+        List<Pair> pairs = new ArrayList<>();
+        while (stringTokenizer.hasMoreElements()) {
+            int left = parseInt(stringTokenizer.nextToken());
+            int right = parseInt(stringTokenizer.nextToken());
+            pairs.add(new Pair(left, right));
+        }
+        pairs.sort(Comparator.comparingInt(Pair::getLeft));
+        return pairs;
+    }
+}
+
+class Pair {
+    private int left;
+    private int right;
+
+    public Pair(int left, int right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public boolean isDuplicate(Pair target) {
+        return this.left == target.getLeft() || this.right == target.getRight()
+                || this.left == target.getRight() || this.right == target.getLeft();
+    }
+
+    public int getLeft() {
+        return left;
+    }
+
+    public int getRight() {
+        return right;
+    }
+}

--- a/kimyeonsup/algospot/SynchronizingClocks.java
+++ b/kimyeonsup/algospot/SynchronizingClocks.java
@@ -1,0 +1,64 @@
+package jmb;
+
+import static java.lang.Integer.max;
+import static java.lang.Integer.parseInt;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class SynchronizingClocks {
+
+    private static int MAX = 9999;
+    private static int[][] switchs = {
+          // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15
+            {1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            {0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0},
+            {0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1},
+            {1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0},
+            {0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0},
+            {1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
+            {0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
+            {0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1},
+            {0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+            {0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0}
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        int testcase = parseInt(bf.readLine());
+
+        while (testcase-- > 0) {
+            int[] clocks = Arrays.stream(bf.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+
+            int result = solve(clocks, 0);
+            if (result >= MAX) {
+                result = -1;
+            }
+            System.out.println(result);
+        }
+    }
+
+    private static int solve(int[] clocks, int switchNumber) {
+        if (switchNumber == 10) {
+            return Arrays.stream(clocks).allMatch(clock -> clock == 12) ? 0 : MAX;
+        }
+
+        int result = MAX;
+        for (int count = 0; count < 4; count++) {
+            result = Math.min(result, count + solve(clocks, switchNumber + 1));
+            push(clocks, switchNumber);
+        }
+        return result;
+    }
+
+    private static void push(int[] clocks, int switchNumber) {
+        for (int clock = 0; clock < switchs[switchNumber].length; clock++) {
+            if (switchs[switchNumber][clock] == 1) {
+                clocks[clock] += 3;
+                if (clocks[clock] == 15) clocks[clock] = 3;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제명 : ``` 소풍 ```
> 시간 복잡도 :  O(N!), 공간 복잡도 : O(N)

### 1. 풀이 과정
소풍문제는 학생들 짝을 지어주는 문제다. 0~n까지 학생과 학생 서로가 친구인 정보가 쌍으로 주어진다. 이 때 모든 학생을 짝지어줄 수 있는 경우의 수를 구해야 한다.
해당 문제는 간단히 모든 학생들을 짝지어주면된다.

**어떻게 짝을 지어줄까?**
서로 친구인 정보를 기준으로 짝을 선택하고 다음 짝을 선택하면 된다. 
여기서 알아야할 것은 짝을 선택하고 그 다음 짝을 선택할 때 남아있는 모든 짝을 탐색해야한다.

- 짝1, 짝2, 짝3, 짝4, 짝5, 짝6 이 있다고 했을 때

```
짝1
짝1 - 짝2 - ...
짝1 - 짝3 - ....
짝1 - 짝4 
짝1 - 짝5
짝1 - 짝6
```
이런 식으로 트리 구조로 탐색을 하게된다. 그러면 `짝1 - 짝2` 에서 다음 선택을 할 때도 나머지 모든 짝을 한번씩 선택 한 경우를 탐색을 한다. 그렇게 가능한 모든 조합을 구하면 된다.
- 해당 방법 복잡도는 높을 수 있지만 간단히 풀 수 있다.
- 위 풀이 방법은 재귀호출로 구현할 수 있다.

---


## 문제명 : ``` Board Cover ```
> 시간 복잡도 :  O(3^k), 공간 복잡도 : 

### 1. 풀이 과정
Y * X 크기의 칸이 주어지고 각 칸은 검정색 또는 흰색칸으로 되어있을 때 흰색 칸에 L자 형태의 블록으로 채우는 경우의 수를 구하는 문제다.
- L자 블록 회전 방향은 자유롭게 할 수 있다.
해당 문제는 제한시간 내에 풀지 못해서 책을 보면서 풀었다. 이것도 경우의 수를 구하는 문제고, 완전탐색 + 재귀호출로 풀 수 있었다.
일단, L자 형태의 블록은 3칸을 차지 한다. 그래서 흰색 칸이 3의 배수가 아니면 구할 수 없다고 한다.

그리고 3의 배수인 경우에는 탐색을 한다. 풀이는 소풍 문제와 비슷하지만 L자 블록 방향을 선택해야되는 것과, 검정 블록과 board가 있다는 점만 추가 됐다. **소풍** 문제는 짝을 선택했다면, 이번 문제는 블록을 선택할 때 고려해야할 방향을 모두 탐색하면 된다. 그렇게 흰 칸을 모두 채우면 되고, 몇가지 조건까지 고려하면 통과 된다.

1. 블록 겹침
2. 검은 블록 
3. 보드의 크기

여기서 주의할 점은 무조건 탐색은 왼쪽 위부터 시작한다. 마찬가지로 중복을 해결해야되는데 블록을 놓는 순서를 정해주는 것이다.

---

## 문제명 : ``` Sync Clocks ```
> 시간 복잡도 :  , 공간 복잡도 : 

### 1. 풀이 과정
마찬가지로 제한 시간내에 풀지 못해 책을 참고했다. ㅎㅎ
아직 이해가 덜 되어서.. 내일 다시 리뷰할 생각이다.

---
## 2 주차 KPT
### Keep
- 변수명 잘 짓기

### Problem
1주차 오프라인에서 페어프로그래밍을 했을 때 문제를 어렵게 접근하고 있다고 느꼈다. 그래서 최대한 쉽고 간단하게 생각하려고 노력했다.
하지만 쉽지 않았다. 문제 요구사항을 정리하고 해결해야할 문제를 작게 조각내고 정리하고 문제를 푸는데, 문제를 작게 조각내는게 잘 되지 않는 것 같다. 

### Try
- 문제 쉽게 접근하기