### PR TITLE
최동현/ 1기 2주차 / 3문제

### DIFF
--- a/choidonghyeon/java/AGS/BoardCover.java
+++ b/choidonghyeon/java/AGS/BoardCover.java
@@ -1,0 +1,111 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BoardCover {
+    static int H;
+    static int W;
+    static char[][] board;
+    static boolean[][] visited;
+    static int whites;
+    static int answer;
+    static int cnt;
+    static int[][][] blocks = {{{0, 0}, {1, 0}, {0, 1}}, {{0, 0}, {0, 1}, {1, 1}}, {{0, 0}, {1, 0}, {1, 1}},
+            {{0, 0}, {1, 0}, {1, -1}}};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+        for (int i = 0; i < T; i++) {
+            st = new StringTokenizer(br.readLine());
+            H = Integer.parseInt(st.nextToken());
+            W = Integer.parseInt(st.nextToken());
+
+            board = new char[H][W];
+            whites = 0;
+
+            for (int y = 0; y < H; y++) {
+                String line = br.readLine();
+                for (int x = 0; x < W; x++) {
+                    board[y][x] = line.charAt(x);
+                    if (board[y][x] == '.') {
+                        whites++;
+                    }
+                }
+            }
+
+            if (whites == 0) {
+                System.out.println(1);
+                continue;
+            }
+
+            if (whites % 3 != 0) {
+                System.out.println(0);
+                continue;
+            }
+            answer = 0;
+            cnt = 0;
+            visited = new boolean[H][W];
+            solve();
+
+            System.out.println(answer);
+        }
+    }
+
+    public static void solve() {
+        if (cnt == whites) {
+            answer += 1;
+            return;
+        }
+
+        for (int y = 0; y < H; y++) {
+            for (int x = 0; x < W; x++) {
+                if (board[y][x] == '#' || visited[y][x]) {
+                    continue;
+                }
+                for (int i = 0; i < 4; i++) {
+                    if (!blockable(y, x, i)) {
+                        continue;
+                    }
+                    changeBlockVisited(y, x, i, true);
+                    solve();
+                    changeBlockVisited(y, x, i, false);
+                }
+                return;
+            }
+        }
+    }
+
+    private static boolean blockable(int y, int x, int type) {
+        for (int[] block : blocks[type]) {
+            int my = y + block[0];
+            int mx = x + block[1];
+
+            if (!inRange(my, mx) || visited[my][mx] || board[my][mx] == '#') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void changeBlockVisited(int y, int x, int type, boolean visitedMark) {
+        for (int[] block : blocks[type]) {
+            int my = y + block[0];
+            int mx = x + block[1];
+
+            visited[my][mx] = visitedMark;
+        }
+        if (visitedMark) {
+            cnt += 3;
+        } else {
+            cnt -= 3;
+        }
+    }
+
+    private static boolean inRange(int y, int x) {
+        return 0 <= y && y < H && 0 <= x && x < W;
+    }
+}

--- a/choidonghyeon/java/AGS/ClockSync.java
+++ b/choidonghyeon/java/AGS/ClockSync.java
@@ -1,0 +1,86 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class ClockSync {
+    static int INF = 100000000;
+    static int answer;
+    static int[] clocks;
+    static int pushCnt;
+    static int[][] switches = new int[][]{
+            {0, 1, 2},
+            {3, 7, 9, 11},
+            {4, 10, 14, 15},
+            {0, 4, 5, 6, 7},
+            {6, 7, 8, 10, 12},
+            {0, 2, 14, 15},
+            {3, 14, 15},
+            {4, 5, 7, 14, 15},
+            {1, 2, 3, 4, 5},
+            {3, 4, 5, 9, 13},
+    };
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        int T = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < T; i++) {
+            clocks = new int[16];
+            pushCnt = 0;
+            answer = INF;
+
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 16; j++) {
+                clocks[j] = (Integer.parseInt(st.nextToken()) / 3) % 4;  // 12 -> 0  3-> 1 6 -> 2 9 -> 3
+            }
+            solve(0);
+
+            if (answer == INF) { //완전 탐색결과 조건을 만족하는 경우가 없다면
+                answer = -1;
+            }
+            sb.append(answer).append("\n");
+        }
+
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+    }
+
+    private static void solve(int numSwitch) {
+        if (numSwitch == 10) { ///마지막 스위치까지 다 따져봤다면
+            calculateAnswer(); // 누른 횟수를 최신화하는 메서드
+            return;
+        }
+
+        solve(numSwitch + 1);  //현재 스위치를 누르지 않는 경우 다음 스위치로 바로 진행
+        for (int i = 0; i < 3; i++) {
+            pushSwitch(numSwitch);
+            pushCnt += 1;
+            solve(numSwitch + 1);
+        }
+        pushSwitch(numSwitch); //3번의 스위치를 눌렀으므로 다시 원상 복귀 시키기위해 한번더 스위치 누름 (4번 누르면 맨처음상태로 원상복귀)
+        pushCnt -= 3; //위에서 3번스위치를 누른 횟수를 다시 차감(백트래킹)
+    }
+
+    private static void pushSwitch(int numSwitch) {
+        for(int clock : switches[numSwitch]) {
+            clocks[clock] = (clocks[clock] + 1) % 4;
+        }
+    }
+
+    private static void calculateAnswer() {
+        for (int clock: clocks) {
+            if (clock != 0) {
+                return;
+            }
+        }
+        answer = Math.min(answer,pushCnt);
+    }
+}

--- a/choidonghyeon/java/AGS/Picnic.java
+++ b/choidonghyeon/java/AGS/Picnic.java
@@ -1,0 +1,70 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Picnic {
+    static int n;
+    static int m;
+    static int[][] friends;
+    static int cnt;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+        int T = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < T; i++) {
+            st = new StringTokenizer(br.readLine());
+            n = Integer.parseInt(st.nextToken());
+            m = Integer.parseInt(st.nextToken());
+            friends = new int[m][2];  // [[0,1],[1,2],[0,3] ...]
+
+            st = new StringTokenizer(br.readLine());
+
+            for (int j = 0; j < m; j++) {
+                friends[j][0] = Integer.parseInt(st.nextToken());
+                friends[j][1] = Integer.parseInt(st.nextToken());
+            }
+            cnt = 0; //정적 변수 초기화
+            backtrack(0, new HashSet<>());
+            sb.append(cnt).append("\n");
+        }
+
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    public static void backtrack(int idx, Set<Integer> studentSet) {
+        if (studentSet.size() == n) {
+            cnt += 1;
+            return;
+        }
+
+        for (int i = idx; i < m; i++) {
+//            if (studentSet.size() + (m - i) * 2 < n) { 남은 친구쌍을 모두 선택해도 총 학생수를 채울수없다면 종료
+//                return;
+//            } 해당 코드 있을시 112ms 없을시 96ms
+
+            if (studentSet.contains(friends[i][0]) || studentSet.contains(friends[i][1])) {
+                continue;
+            }
+
+            studentSet.add(friends[i][0]);
+            studentSet.add(friends[i][1]);
+
+            backtrack(i + 1, studentSet);
+
+            studentSet.remove(friends[i][0]);
+            studentSet.remove(friends[i][1]);
+        }
+    }
+}


### PR DESCRIPTION
## 문제명 : ``` 소풍 ```

### 1. 풀이 과정
백트래킹과 `Set`자료구조를 이용해서 풀었습니다. 친구쌍을 2차원 배열로 받은 다음 이 배열 자체에서 인덱스를 가지고 
반복문을 통해 백트래킹을 할 수 있도록 구현했습니다.
문제를 풀고나서 다른 풀이와 비교해봤을때, 보통 인접 행렬로 구성한 경우가 많았는데 거기까지 생각이 발전하지는 못했던것 같습니다.

백트래킹 내부에서 현재 탐색하는 친구 쌍의 학생들이 `Set`에 들어 있지 않은 경우만 계속해서 갱신해나가는 느낌으로  
최대한 직관적으로 풀어내려했습니다.

다만, 조금 의아한 부분은 인덱스로 접근했기때문에 남은 쌍의 수와 학생수를 계산했을때 더이상 백트래킹을 진행하는 것이 의미가 없을때
`return`하는 최적화 코드를 작성했는데 오히려 시간을 더 소요하는 것이였습니다. 딱히 의미가 없는 최적화여서 그런지는 잘 모르겠습니다.
[해당부분](https://github.com/coding-test-java/problems/pull/29/files#diff-4e7fe014dadf1e77e21b2904d2ccf0e0cee6b8b4922ee178784d2d0fc0c173a4R53) 

최대한 직관적으로 접근하려했고, 풀이시간은 줄일 수 있었지만 문제의 의도에선 조금 멀어진게 아닌가 싶었던 경험이었습니다.

---


## 문제명 : ``` 게임판 덮기 ```
### 1. 풀이 과정

여러모로 굉장히 헤맸던 문제입니다. 해당 문제처럼 보드와 도형의 회전에 관련한 내용이 나오면 항상 많은 고민이 들고했는데 
이번에도 같았습니다. 처음엔 백트래킹을 어느정도 인지한채로 `DFS`,`DP`로 접근하면서 헤맸고, 결국엔 보드 전체에 완전탐색과
백트래킹으로 해결할 수 있었습니다

이 문제에서 핵심은 블럭의 유형 4가지를 배열 형태로 정의하는 것과 보드 전체를 대상으로 백트래킹을 진행하는 것이라고 판단됩니다.
흐름은 다음과 같습니다.

1. 보드의 배열을 입력 받으면서 흰색의 셀 개수 카운트
2. 보드 전체 셀을 이중 반복문으로 돌면서 가능한 블록의 유형을 하나씩 백트래킹 진행 (`visited` 배열로 선택한 셀 기록 + 카운트) 
3. 카운트한 셀이 처음에 셌던 흰색의 전체 셀 개수와 같으면 정답 경우의 수 + 1

구현적인 요소가 다소 있고, 그림을 보자마자 `DFS`나 `DP`에 강하게 집착한게 시간이 많이 소요되었던 이유가 아닌가 싶습니다.

---
## 문제명 : ``` 시계 맞추기 ```
### 1. 풀이과정
책의 6장에 어떤 내용이 있는지 모르겠지만 일단 이번주차 3문제 완전탐색 그리고 백트래킹을 거의 사용하게 되었네요.
이번 문제는 사실 대놓고 완전탐색 문제였습니다. 하지만 제 습관이 완전탐색을 먼저 떠올리는게 아니라 자꾸만 `DP` 나 그리디같은 알고리즘들을 먼저떠올리고 여기서 자꾸 미로 속에 갇히는 것 같습니다. 

이 문제는 만약 스위치를 모두 누르는 경우의 수는 과연 몇가지 일 것인가? 에 대해 한번 계산해봤다면 주저없이 완전 탐색으로 쉽게 접근했을 것 같습니다.

그전에 중요한 사실은 `스위치를 4번 누르면 원상 복귀 된다` 입니다. 즉 스위치를 4번이상 누르는 것은 무의미한 일이며 
각 스위치에서 선택할 수 있는 사항은 다음과 같습니다.

+ 누르지않는다.
+ 1번 누른다.
+ 2번 누른다.
+ 3번 누른다.

따라서 각 스위치는 독립 시행이며 4개의 옵션이 있으므로 문제에서 탐색해야할 모든 경우의 수는 
4<sup>10</sup> = 1048576 개입니다.













