### PR TITLE
홍용준 / 1기 3주차 / 3문제

### DIFF
--- a/yongjun/AGS/week3/FanMeeting.java
+++ b/yongjun/AGS/week3/FanMeeting.java
@@ -1,0 +1,48 @@
+package AGS.week3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.util.StringTokenizer;
+
+public class FanMeeting {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int testCase = Integer.parseInt(st.nextToken());
+        while (testCase-- > 0) {
+            String singer = br.readLine();
+            String fans = br.readLine();
+            System.out.println(KARATSUBA_ALGORITHM(singer, fans));
+        }
+    }
+
+    static int KARATSUBA_ALGORITHM(String x, String y) {
+
+        String singer = replaceStringToInteger(x);
+        String fans = replaceStringToInteger(y);
+
+        BigInteger a = new BigInteger(singer, 2);
+        BigInteger b = new BigInteger(fans, 2);
+
+        int fan_range = fans.length();
+        int singer_range = singer.length();
+        int result = 0;
+        for (int i = 0; i <= fan_range-singer_range; i++) {
+            if (a.and(b).equals(BigInteger.ZERO)) {
+                result++;
+            }
+            b = b.shiftRight(1);
+        }
+
+        return result;
+    }
+
+    // 이진수로 변환
+    static String replaceStringToInteger(String input) {
+        return input.replace("M", "1").replace("F", "0");
+    }
+}
+

--- a/yongjun/AGS/week3/Fence.java
+++ b/yongjun/AGS/week3/Fence.java
@@ -1,0 +1,57 @@
+package AGS.week3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Fence {
+    static int[] fence;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int c = Integer.parseInt(st.nextToken());
+        while (c-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+            fence = new int[n + 1];
+            st = new StringTokenizer(br.readLine());
+            for (int i = 0; i < n; i++) {
+                fence[i] = Integer.parseInt(st.nextToken());
+            }
+            System.out.println(solve(0, n - 1));
+
+        }
+    }
+
+    static int solve(int left, int right) {
+        // 기저사례 : left와 right의 값이 같으면 더 이상 진행할 수 없으므로 left 값을 반환
+        if (left == right) {
+            return fence[left];
+        }
+        int mid = (left + right) / 2;
+        // 분할 정복을 통해 절반으로 나눈 값 중, 더 큰 값을 선택한다.
+        int maxValue = Math.max(solve(left, mid), solve(mid + 1, right));
+        // mid, mid + 1의 길이를 가지고 있는 사각형을 고려한다.
+        // 더 작은 값에 2를 곱해서 직사각형을 구한다.
+        int low = mid;
+        int high = mid + 1;
+        int height = Math.min(fence[low], fence[high]);
+        // 분할정복을 통해 나온 값과 mid에 걸친 값과 비교해서 큰 값을 반환한다.
+        maxValue = Math.max(maxValue, height * 2);
+
+        while (low > left || high < right) {
+            // 항상 높이가 더 높은 쪽으로 확장한다.
+            if (high < right && (low == left || fence[high + 1] > fence[low - 1])) {
+                high += 1;
+                height = Math.min(height, fence[high]);
+            } else {
+                low -= 1;
+                height = Math.min(height, fence[low]);
+            }
+            maxValue = Math.max(maxValue, height * (high - low + 1));
+        }
+        return maxValue;
+    }
+}

--- a/yongjun/AGS/week3/QuadTree.java
+++ b/yongjun/AGS/week3/QuadTree.java
@@ -1,0 +1,45 @@
+package AGS.week3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.text.StringCharacterIterator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class QuadTree {
+    static String pic;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int c = Integer.parseInt(st.nextToken());
+
+        while (c-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            pic = st.nextToken();
+            StringCharacterIterator iterator = new StringCharacterIterator(pic);
+            System.out.println(reverse(iterator));
+        }
+    }
+
+    static String reverse(StringCharacterIterator picture) {
+        char head = picture.current();
+        picture.next();
+        /*
+        head의 값이 w or b이면 char 값을 반환한다.
+        이 조건문을 통해 만약 head의 값이 x이면 return을 하지 않고 재귀 함수를 호출하게 한다.
+         */
+        if (head == 'w' || head == 'b') {
+            return String.valueOf(head);
+        }
+
+        String topLeft = reverse(picture);
+        String topRight = reverse(picture);
+        String bottomLeft = reverse(picture);
+        String bottomRignt = reverse(picture);
+
+        return "x" + bottomLeft + bottomRignt + topLeft + topRight;
+    }
+}


### PR DESCRIPTION
## 문제명 : ``` 쿼드 트리 뒤집기 ```
> 시간 복잡도 : O(N) 92ms , 공간 복잡도 : 

### 1. 풀이 과정
```
문자열을 저장한 뒤, 뒤집은 순서로 출력을 하려고 했으나 문자열을 저장하면 1 테라가 된다는 책의 내용을 읽고 빠르게 다른 방법을 찾았습니다.
<분할 정복>
1. StringCharacterIterator을 통해 문자열을 순서대로 읽는다.
2. head(0번 인덱스에 위치한 문자)가 x라면 재귀를 통해 내부 트리에 진입합니다.
3. head가 w 또는 b라면 반환을 하고 거꾸로 뒤집은 순서로 출력을 합니다.
```

```
1 2
3 4
(뒤집으면)
3 4
1 2
```

[StringCharacterIterator](https://solution-is-here.tistory.com/210)을 통해 문자열을 탐색 했습니다. 

---


## 문제명 : ```울타리 잘라내기```
> 시간 복잡도 12684ms:  , 공간 복잡도 : 

### 1. 풀이 과정
```
문제를 보자마자 모든 경우를 전부 고려해서 가장 큰 넓이를 구하면 되지 않을까? 라는 생각을 하였지만 판자의 수가 20_000까지이므로
분할 정복을 선택했습니다.

이진 탐색과 비슷하게 절반으로 나눈 뒤, 오른쪽에서 긴 직사각형, 왼쪽에서 가장 긴 직사각형을 구했습니다.
이때 두 부분에 모두 걸치는 사각형도 고려해야 했습니다.

그러므로 사각형이 입력 전체를 덮을 때 까지 확장해 나가면서 가장 큰 값을 찾았습니다.
max 함수를 통해 기존의 가장 큰 값과 두 부분에 걸쳐있는 사각형 중 큰 값을 찾은 뒤 출력했습니다.
```
---

## 문제명 : ```팬미팅```
> 시간 복잡도 248ms:  , 공간 복잡도 : 

### 1. 풀이 과정
```
남성(1) 남성(1)이면 비트 연산(&, and) 결과가 1이다.
이 점을 이용하면 쉽게 풀 수 있는 문제였다.
팬의 숫자에서 가수의 숫자를 제외한 만큼에서 1을 더한만큼 반복하면서 비트 연산을 한다.
이때 이진수의 비트를 long이 아닌 BigInteger에 담아야 한다. (long으로 커버가 안 되기 때문)
```
@goodchoi  변수에 대한 힌트를 얻었다.

---


## 3주차 KPT

### Keep
1. 매일 알고리즘을 두 문제씩 푸는 습관을 들이니 문제를 파악하는 능력이 조금 발전한 것 같다.
2. 문제를 도식화 한 뒤, 해결하려는 습관이 생겼다.
### Problem
1. 너무 쉽게 포기하는 습관이 아직 남아있다.
### Try
1. 적어도 1시간 반은 시도해보고 포기하려는 습관을 만들자
