### PR TITLE
최동현 / 1기 6주차 / 3문제

### DIFF
--- a/choidonghyeon/java/AGS/Snail.java
+++ b/choidonghyeon/java/AGS/Snail.java
@@ -1,0 +1,80 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.util.StringTokenizer;
+
+public class Main {
+	static BigInteger[] factorials = new BigInteger[1001]; //factorials[n] = n! factorial 연산을 memorizing 처리
+	static double[] sunnys = new double[1001];  //sunnys[n] = Math.pow(0.25,n) 제곱연산을 memorizing처리.
+	static double[] rainys = new double[1001];
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int T = Integer.parseInt(br.readLine());
+
+		initializeFactorials();
+		initializeRainys();
+		initializeSunnys();
+
+		while (T-- > 0) {
+			st = new StringTokenizer(br.readLine());
+			int n = Integer.parseInt(st.nextToken());
+			int m = Integer.parseInt(st.nextToken());
+
+			double possibility = 0;
+
+			int maxSunnyDays = 0;
+
+			if (n > 2 * m) { //우물의 깊이가 days의 두배가 넘는다면 모든 날에 비가와서 하루에 2m 씩 올라가도 우물의 끝에 도달하지 못함.
+				print(0.0d);
+				continue;
+			} else if (n <= m) { //우물의 깊이가 days보다 작거나 같다면 모든 날에 비가 오거나 오지않더라도 무조건 우물의 끝에 도달함.
+				print(1.0d);
+				continue;
+			} else {
+				maxSunnyDays = 2 * m - n;  //최대 비가 오지 않을 수 있는 날의 수
+			}
+
+			for (int i = 0; i < maxSunnyDays + 1; i++) {
+				possibility += calculateCombination(m, i) * sunnys[i] * rainys[m-i];  // nCr * 0.25의 i 제곱 * 0.75의 (i-m) 제곱
+			}
+			print(possibility);
+		}
+	}
+
+	private static void print(double value) {
+		System.out.printf("%.10f\n", value);
+	}
+
+	private static void initializeRainys() {
+		rainys[0] = 1.0d;
+		for (int i = 1; i < 1001; i++) {
+			rainys[i] = rainys[i-1] * 0.75;
+		}
+	}
+
+	private static void initializeSunnys() {
+		sunnys[0] = 1.0d;
+		for (int i = 1; i < 1001; i++) {
+			sunnys[i] = sunnys[i-1] * 0.25;
+		}
+	}
+
+	private static void initializeFactorials() {
+		factorials[0] = BigInteger.ONE;
+		factorials[1] = BigInteger.ONE;
+		for (int i = 2; i < 1001; i++) {
+			factorials[i] = factorials[i - 1].multiply(BigInteger.valueOf(i));
+		}
+	}
+
+	/**
+	 * 조합 연산
+	 * calculateCombination(int n, int r) = nCr
+	 * -> n!/ (n-r)! * r!
+	 */
+	private static double calculateCombination(int n, int r) {
+		return factorials[n].divide(factorials[n - r].multiply(factorials[r])).doubleValue();
+	}
+}

--- a/choidonghyeon/java/AGS/Tiling2.java
+++ b/choidonghyeon/java/AGS/Tiling2.java
@@ -1,0 +1,31 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Main {
+	public static final int MOD = 1000000007;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int c = Integer.parseInt(br.readLine());
+		int[] cases = new int[c];
+
+		int maxN = 0;
+		for (int i = 0; i < c; i++) {
+			int n = Integer.parseInt(br.readLine());
+			cases[i] = n;
+			maxN = Math.max(n, maxN);
+		}
+
+		int[] dp = new int[maxN + 1]; //모든 케이스에서 상황은 변하지 않으므로 가장 큰 숫자를 기준으로 한번 dp 테이블 초기화 진행
+		dp[1] = 1;
+		dp[2] = 2;
+
+		for (int i = 3; i < maxN + 1; i++) {
+			dp[i] = (dp[i - 1] + dp[i - 2]) % MOD;
+		}
+
+		for (int n : cases) {
+			System.out.println(dp[n]);
+		}
+	}
+}

--- a/choidonghyeon/java/AGS/Tripathcnt.java
+++ b/choidonghyeon/java/AGS/Tripathcnt.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int T = Integer.parseInt(br.readLine());
+
+		while (T-- > 0) {
+			int n = Integer.parseInt(br.readLine());
+			int[][] triangle = new int[n][n];
+
+			for (int i = 0; i < n; i++) {
+				st = new StringTokenizer(br.readLine());
+				for (int j = 0; j < i + 1; j++) {
+					triangle[i][j] = Integer.parseInt(st.nextToken());
+				}
+			}
+
+			int[][][] dp = new int[n + 1][n + 1][2]; //dp[i][j][0]: i,j의 좌표에 도달할 수 있는 최대 경로 길이 dp[i][j][1]: i,j의 좌표에 도달할 수 있는 최대 경로의 수
+			dp[1][1] = new int[]{triangle[0][0],1};
+
+			for (int i = 1; i < n; i++) {
+				for (int j = 0; j < n; j++) {
+					if (dp[i][j][0] == dp[i][j + 1][0]) {
+						dp[i + 1][j + 1][0] = dp[i][j][0] + triangle[i][j];
+						dp[i + 1][j + 1][1] = dp[i][j][1] + dp[i][j + 1][1]; //경로가
+						continue;
+					}
+					if (dp[i][j][0] > dp[i][j + 1][0]) {
+						dp[i + 1][j + 1][0] = dp[i][j][0] + triangle[i][j];
+						dp[i + 1][j + 1][1] = dp[i][j][1];
+						continue;
+					}
+					if (dp[i][j][0] < dp[i][j + 1][0]) {
+						dp[i + 1][j + 1][0] = dp[i][j + 1][0] + triangle[i][j];
+						dp[i + 1][j + 1][1] = dp[i][j + 1][1];
+					}
+				}
+			}
+
+			int maxDistance = 0;
+			int maxDistanceFrequency = 0;
+
+			for (int i = 1; i < n + 1; i++) {
+				if (dp[n][i][0] > maxDistance) {
+					maxDistance = dp[n][i][0];
+					maxDistanceFrequency = dp[n][i][1];
+				} else if (dp[n][i][0] == maxDistance) {
+					maxDistanceFrequency += dp[n][i][1];
+				}
+			}
+
+			System.out.println(maxDistanceFrequency);
+		}
+	}
+}


### PR DESCRIPTION
## 문제명 : ```타일링 방법의 수 세기```
> 시간 복잡도 :  , 공간 복잡도 :

### 1. 풀이 과정
점화식을 잘 떠올린다면 쉽게 접근할 수 있는 문제인 것 같습니다.

저는 점화식을 구할 때, dp[n-2]에서 `2*1`타일을 가로로 추가, dp[n-1]에서 세로로 추가 해서 dp[n]을 구할 수 있다 생각하여

    dp[n] = dp[n-1] + dp[n-2] 

로 구할 수 있었습니다.
또, 문제에서 케이스의 숫자가 주어지지만 문제의 상황은 동일하기 때문에 먼저 케이스들을 입력받고
가장 큰 숫자만큼 `dp`테이블 초기화를 진행해서 반복을 줄였습니다.

---


## 문제명 : ```삼각형 위의 최대 경로의 수 세기```
> 시간 복잡도 :  , 공간 복잡도 :


### 1. 풀이 과정
지난 문제중 `삼각형 위의 최대 경로` 문제를 응용해서 풀었습니다.
단순히 최대 경로의 길이만 구할 때는 2차원의 dp 만 썼지만 `경로의 수`를 구하기위해 3차원 dp로 해결했습니다.

```java
dp[i][j][0] : (i,j)의 항에 도달할 수 있는 최대 경로의 길이
dp[i][j][1] : (i,j)의 항에 도달할 수 있는 최대 경로의 수
```

`삼각형 위의 최대 경로` 문제 풀이에서 경로의 수를 갱신하는 과정이 추가 되었습니다.

---

## 문제명 : ``` 달팽이 ```
> 시간 복잡도 :  , 공간 복잡도 :

### 1. 풀이 과정
딱히 `dp`를 적용하는 것이 떠오르지않아서 약간 수학적으로 접근했던것 같습니다. 풀이는 다음과 같습니다.

우물의 깊이 :n, 일 수 :m
1) n > m * 2 :
    
    모든 날에 비가 와서 매일 `2m`씩 올라간다해도 우물의 끝에 도달할 수 없기때문에 이때 확률은 `0`입니다.
2) n <= m :

    모든 날에 비가 오든 오지않든 항상 우물의 끝에 도달할 수 있으므로 확률은 `1`입니다.

3) 그 외
   
    맑은 날을 기준으로, 가능한 맑은 날의 최대 일 수는 `2 * m - n` 입니다.
     
   ```java
   ex)
   n = 8 m = 4 -> 0일 
   n = 8 m = 5 -> 2일    1 + 1 + 2 + 2 + 2 = [8] 
      :
   ```
   
   이제 가능한 맑은 날의 최대 일수를 찾아냈으니 확률을 구할 수 있다고 생각했습니다.
   맑은 날의 일수를 0 부터 최대 일수까지 반복문을 돌면서 확률을 계속 더해가면 되었습니다.
   ```java
   ex) n= 8 m = 5, 가능한 맑은 날의 최대일수 : 2일
   
   1) 맑은 날의 일수 : 0
   
   nC0 * ((0.25) ** (0)) * ((0.75) **(5))
   
   2) 맑은 날의 일수 : 1
   
   nC1 * ((0.25) ** (1)) * ((0.75)**(4))
   :
   :
   ```
   조합을 사용해서 모든 날중 맑은 날을 선택할 수 있는 모든 경우의 수를 곱해주었습니다. 


조합을 사용할때 계산을 위해서 `factorial`을 필요했고, `dp`로 미리 구해놓았습니다. 이때 최대 1000!까지 필요하므로 정수형 범위를 아득히 넘기 때문에 `BigInteger`를 사용했습니다.

저는 이렇게 풀긴했지만 책의 풀이를 보면 이렇게까지 복잡하게 해결하진 않았습니다. 그냥 이런 풀이도 있구나 하고 봐주시면 감사하겠습니다.

---
