### PR TITLE
김연섭 / 1기 6주차 / 3문제

### DIFF
--- a/kimyeonsup/algospot/Snail.java
+++ b/kimyeonsup/algospot/Snail.java
@@ -1,0 +1,54 @@
+package jmb;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Snail {
+    private static double[][] cache;
+    private static int depth;
+    private static int dayCount;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int testcase = Integer.parseInt(br.readLine());
+        // snail(day, height) = 0.75 * snail(day + 1, height + 2) + 0.25 * snail(day + 1, height + 1)
+        /*
+        4
+        5 4
+        5 3
+        4 2
+        3 2
+        * */
+        while (testcase-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            depth = Integer.parseInt(st.nextToken());
+            dayCount = Integer.parseInt(st.nextToken());
+            cache = new double[dayCount + 2][depth + 2];
+            for (int i = 0; i < dayCount + 2; i++) {
+                Arrays.fill(cache[i], -1);
+            }
+            System.out.println(String.format("%.10f", snail(0, 0)));
+        }
+    }
+
+    private static double snail(int day, int height) {
+        double value = cache[day][height];
+        if (value != -1) {
+            return value;
+        }
+
+        // day가 끝나기 전에 목표에 도달했을 때
+        if (height >= depth) {
+            return 1;
+        }
+        // 기저 사례 장마가 끝나고 우물 끝가지 올라갔을때
+        if (day == dayCount) {
+            return height >= depth ? 1 : 0;
+        }
+
+        return cache[day][height] = 0.75 * snail(day + 1, height + 2) + 0.25 * snail(day + 1, height + 1);
+    }
+}

--- a/kimyeonsup/algospot/Tiling2.java
+++ b/kimyeonsup/algospot/Tiling2.java
@@ -1,0 +1,31 @@
+package jmb;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Tiling2 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int testcase = Integer.parseInt(br.readLine());
+
+        while (testcase-- > 0) {
+            // 타일 가로 길이 n
+            int n = Integer.parseInt(br.readLine());
+            int[] dp = new int[n];
+
+            // dp[n] = dp[n-1] + dp[n-2]
+            // dp[0]과 dp[1] 초기화
+            dp[0] = 1;
+            if (n > 1) {
+                dp[1] = 2;
+                for (int i = 2; i < n; i++) {
+                    dp[i] = (dp[i - 1] + dp[i - 2]) % 1000000007;
+                }
+            }
+
+            System.out.println(dp[n - 1]);
+        }
+    }
+}

--- a/kimyeonsup/algospot/TripathCnt.java
+++ b/kimyeonsup/algospot/TripathCnt.java
@@ -1,0 +1,100 @@
+package jmb;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class TripathCnt {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int testcase = Integer.parseInt(br.readLine());
+        // dp[i][j] = if arr[i-1][j - 1] == arr[i][j-1] ? dp[i-1][j] + dp[i-1][j] : max(dp[i-1][j - 1], dp[i-1][j])
+        /*
+        4
+        1
+        1 1
+        1 1 1
+        1 1 1 1
+        * */
+        while (testcase-- > 0) {
+            int n = Integer.parseInt(br.readLine());
+            int[][] arr = new int[n][n];
+            for (int i = 0; i < n; i++) {
+                StringTokenizer st = new StringTokenizer(br.readLine());
+                int j = 0;
+                while (st.hasMoreElements()) {
+                    int value = Integer.parseInt(st.nextToken());
+                    arr[i][j] = value;
+                    j++;
+                }
+            }
+            System.out.println(solve(n, arr));
+        }
+    }
+
+    /*
+    pathDp = 경로 dp
+    maxValue = 각 행열의 최대 값 dp
+    * */
+    private static int solve(int n, int[][] arr) {
+        int[][] pathDp = new int[n][n];
+        int[][] maxValueDp = new int[n][n];
+
+        pathDp[0][0] = 1;
+        maxValueDp[0][0] = arr[0][0];
+
+        // dp[i][j] = if arr[i-1][j - 1] == arr[i][j-1] ? dp[i-1][j] + dp[i-1][j] : max(dp[i-1][j - 1], dp[i-1][j])
+        for (int i = 1; i < n; i++) {
+            for (int j = 0; j < i + 1; j++) {
+                int number = arr[i][j];
+                setMaxValue(j, i, maxValueDp, number);
+                setPathCount(i, j, pathDp, maxValueDp);
+            }
+        }
+
+        int maxValue = 0;
+        for (int number : maxValueDp[n - 1]) {
+            maxValue = Math.max(maxValue, number);
+        }
+
+        int sum = 0;
+        for (int j = 0; j < n; j++) {
+            if (maxValueDp[n - 1][j] == maxValue) {
+                sum += pathDp[n - 1][j];
+            }
+        }
+        return sum;
+    }
+
+    private static void setPathCount(int i, int j, int[][] pathDp, int[][] maxValueDp) {
+        if (j == 0)  {
+            pathDp[i][j] = pathDp[i - 1][j];
+            return;
+        }
+        if (j == i) {
+            pathDp[i][j] = pathDp[i - 1][j - 1];
+            return;
+        }
+
+        if (maxValueDp[i - 1][j - 1] == maxValueDp[i - 1][j]) {
+            pathDp[i][j] = pathDp[i - 1][j] + pathDp[i - 1][j - 1];
+        } else if (maxValueDp[i - 1][j - 1] > maxValueDp[i - 1][j]){
+            pathDp[i][j] = pathDp[i - 1][j - 1];
+        } else {
+            pathDp[i][j] = pathDp[i - 1][j];
+        }
+    }
+
+    private static void setMaxValue(int j, int i, int[][] maxValueDp, int number) {
+        if (j == 0)  {
+            maxValueDp[i][j] = number + maxValueDp[i - 1][j];
+            return;
+        }
+        if (j == i)  {
+            maxValueDp[i][j] = number +  maxValueDp[i - 1][j - 1];
+            return;
+        }
+        maxValueDp[i][j] = number + Math.max(maxValueDp[i - 1][j - 1], maxValueDp[i - 1][j]);
+    }
+}


### PR DESCRIPTION
## 문제명 : ``` 타일링 방법의 수 세기 ```
> 시간 복잡도 :  O(n), 공간 복잡도 : 

### 1. 풀이 과정
점화식 : `dp[n] = dp[n-1] + dp[n-2]`

이전에 풀었던 문제라 어렵지 않게 풀었습니다. n길이의 타일조합이 이전 n-1길이의 타일 조합 패턴에서 몇개만 추가됐다는 것을 알고 0~n까지 경우의 수를 구해봤다면 n-1 타일과 n-2의 타일 경우의 수가 n의 경우의 수가 된다는 것을 파악할 수 있습니다.


---

## 문제명 : ``` 삼각형 최대 합 경로의 수 세기 ```
> 시간 복잡도 :  O(n^2), 공간 복잡도 : 

### 1. 풀이 과정
점화식 : `dp[i][j] = if max[i-1][j - 1] == max[i][j-1] ? dp[i-1][j] + dp[i-1][j] : max(dp[i-1][j - 1], dp[i-1][j])`
이전 문제인 삼각형의 최대 합 구하기를 풀어봤으면 어렵지 않게 풀 수 있을 것 같습니다. 이전 문제는 dp i행의 열에서 최댓값이 되는 값을 구해서 저장했습니다. 
이와 같은 상향식 방식을 이용했을 때 경로의 수 패턴을 살펴보면 열 각 끝은 무조건 1이 되는 것을 알 수 있습니다.

```
1
1 1
1 n n 1
1 n n n 1
```

위와 같이 된다는 것을 알 수 있습니다. 그러면 이제 n이 되는 부분만 구하면 됩니다.
n으로 올 수 있는 경로는 2가지 입니다. 경로는 아래 또는 오른쪽 아래라 했으니 반대로 `dp[i - 1][j], dp[i - 1][j - 1]` 입니다.
여기서 최대합이라고 했으니 두 경로 중 더 큰 값이 되는 경로를 선택하면 됩니다. 그리고 마지막으로 두 경로의 값이 같다면 입니다.
같다면 두 곳에서 모두 올 수 있으니 두 경로를 모두 더하면 됩니다.
그렇게 `n - 1` 모두 탐색하고 n - 1 행의 최대 합을 구하고 최대합이 되는 모든 경로의 수를 더하면 값이 나옵니다.

---

## 문제명 : ``` 삼각형 최대 합 경로의 수 세기 ```
> 시간 복잡도 :  , 공간 복잡도 : 

### 1. 풀이 과정

책을 참고에서 풀었습니다. 일단 이전 문제와 유사하게 비가 오고 오지 않을 때를 모두 탐색해야 된다는 것을 알았으나 중복을 해결하기 위해 dp를 어떻게 써야할지 점화식이 세워지지 않았습니다. 책 풀이 방식을 보면 하향식인 재귀 호출로 문제를 풉니다. 점화식은 다음과 같습니다.
`dp[day][height] = 0.75 * snail(day + 1, height + 2) + 0.25 * (day + 1, height + 1)`

즉, dp[day][height]의 의미는 day번째날 높이가 height 일때부터 마지막날 우물을 넘을 확률이다.

## KPT

### Keep
- 변수명 잘 짓기
- 쉽게 생각하기
- 주석 달기

### Problem
- 상향식과 하향식 이해
- 하향식에서 중복을 해결하는 방법

### Try
- 리팩토링하기
- Top-Down 방식의 이해
