### PR TITLE
임영우 / 2기 3주차 / 2문제

### DIFF
--- a/youngwoo/BOJ/BOJ_15681.java
+++ b/youngwoo/BOJ/BOJ_15681.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ_15681 {
+    static int N, R, Q;
+    //N: 트리의 정점의 수, R:트리의 루트 정점 번호, Q:처리해야 하는 쿼리의 수
+    static List<Integer>[] adj;
+    //인접 리스트 방식으로 트리를 나타낸다. adj[i] = 정점 i와 연결된 정점 번호들의 리스트
+    static int[] size;
+    //size[i] = 정점 i를 루트로 하는 서브트리에 포함된 정점의 수를 저장
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        Q = Integer.parseInt(st.nextToken());
+
+        //인접 리스트 초기화
+        adj = new ArrayList[N + 1];
+        for (int i = 1; i <= N; i++) {
+            adj[i] = new ArrayList<>();
+        }
+
+        for (int i = 1; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            // 두 노드를 서로의 인접 리스트에 추가
+            adj[u].add(v);
+            adj[v].add(u);
+        }
+
+        size = new int[N + 1];
+        dfs(R, -1); //서브트리의 크기를 계산하기 위해 dfs 호출
+
+        for (int i = 0; i < Q; i++) {
+            int v = Integer.parseInt(br.readLine());
+            System.out.println(size[v]);
+        }
+    }
+
+    static void dfs(int cur, int parent) {
+        size[cur] = 1;
+        for (int next : adj[cur]) {
+            if (next == parent) continue; //백트래킹을 피하기 위해 부모 노드를 건너뛴다
+            dfs(next, cur); //자식 노드의 서브트리 크기를 계산하기 위해 재귀적으로 dfs를 호출
+            size[cur] += size[next]; //계산된 자식 노드의 서브트리 크기를 현재 노드의 서브트리 크기에 추가
+        }
+    }
+}

--- a/youngwoo/BOJ/BOJ_2583.java
+++ b/youngwoo/BOJ/BOJ_2583.java
@@ -1,0 +1,105 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_2583 {
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+
+    static int M, N, K;
+    static int[][] map;
+    static boolean[][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer tk;
+
+        tk = new StringTokenizer(br.readLine(), " ");
+
+        M = Integer.parseInt(tk.nextToken());
+        N = Integer.parseInt(tk.nextToken());
+        K = Integer.parseInt(tk.nextToken());
+
+        map = new int[M+1][N+1];
+        visited = new boolean[M+1][N+1];
+
+        for (int k = 0; k < K; k++) {
+            tk = new StringTokenizer(br.readLine(), " ");
+            int fx = Integer.parseInt(tk.nextToken());
+            int fy = Integer.parseInt(tk.nextToken());
+            int sx = Integer.parseInt(tk.nextToken());
+            int sy = Integer.parseInt(tk.nextToken());
+
+            makeSquare(fy+1, fx+1, sy, sx);
+        }
+
+        int areaCnt = 0;
+        PriorityQueue<Integer> pQ = new PriorityQueue<>((a, b) -> a-b);
+        for (int i = 1; i <= M; i++) {
+            for (int j = 1; j <= N; j++) {
+                if(!visited[i][j]){
+                    pQ.offer(BFS(i, j));
+                    areaCnt++;
+                }
+            }
+        }
+        System.out.println(areaCnt);
+        while (!pQ.isEmpty()){
+            System.out.print(pQ.poll()+" ");
+        }
+    }
+
+    private static void printArr() {
+        for (int i = 1; i <= M; i++) {
+            for (int j = 1; j <= N ; j++) {
+                System.out.print(map[i][j]+" ");
+            }
+            System.out.println();
+        }
+        System.out.println();
+    }
+
+    //입력 좌표 기반으로 사각형 영역을 맵에 표시한다
+    private static void makeSquare(int fx, int fy, int sx, int sy) {
+
+        for (int r = fx; r <= sx; r++) {
+            for (int c = fy; c <= sy ; c++) {
+                visited[r][c] = true;
+                map[r][c] = 1;
+            }
+        }
+
+    }
+
+    //주어진 좌표로부터 연결된 영역 탐색
+    //탐색된 셀 개수를 영역 크기로 변환
+    //dx, dy배열: 상화좌우 이동방향 오프셋 저장
+    private static int BFS(int i, int j) {
+        int res = 1;
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[]{i, j});
+        visited[i][j] = true;
+        while (!queue.isEmpty()){
+            int[] xy = queue.poll();
+            int x = xy[0];
+            int y = xy[1];
+
+            for (int d = 0; d < 4; d++) {
+                int sx = x + dx[d];
+                int sy = y + dy[d];
+
+                if(sx < 1 || sx > M || sy < 1 || sy > N || visited[sx][sy]) continue;
+
+                res++;
+                visited[sx][sy] = true;
+                queue.offer(new int[]{sx, sy});
+            }
+        }
+
+        return res;
+    }
+}


### PR DESCRIPTION
## 문제명 : ``` 영역 구하기 ```

### 풀이 과정
```
BFS와 PriorityQueue를 썼습니다. 입력 좌표를 기반으로 사각형 영역을 맵에 1로 표시합니다.
BFS: 각 빈 칸에서 시작하여 연결된 빈 칸 들을 모두 탐색하게 하였습니다. 탐색 된 칸의 개수가 해당 영역의 크기는 해당 영역
의 크기입니다. PriorityQueu:  BFS 결과인 각 영역 크기를 오름차순으로 정렬합니다.
구현 과정에서 런타임 에러가 떠 방법을 찾던 중에 우선순위 큐를 방식이 있는 것을 알고 참조하였습니다.
```
## 문제명 : ``` 트리와 쿼리 ```

### 풀이 과정
```
트리와 DFS를 사용하였습니다. 트리: 입력으로 주어진 간선 정보를 이용하여 트리를 구성합니다. 인접 리스트 또는 배열 등을 사용하여 트리를 표현합니다. DFS: 서브트리 크기 계산 및 size 배열에 서브트리에 속한 정점의 개수를 계산한 값을 저장합니다.
DFS를 사용하려 하였습니다. 트리로 접근을 하여야 하는 것 같은데 감이 잡히지 않아 정답을 참조하였습니다. 같은 방문지(정점)
를 2번 방문할 수 있게 하여야 한다는데 DFS 함수안에서 2번 반복하기가 어려워 문제가 있었습니다.
```

## 문제명 : ``` 여행 경로 ```

### 풀이 과정
```
DFS를 사용하려 하였습니다. 트리로 접근을 하여야 하는 것 같은데 감이 잡히지 않아 정답을 참조하였습니다. 같은 방문지(정점)
를 2번 방문할 수 있게 하여야 한다는데 DFS 함수안에서 2번 반복하기가 어려워 문제가 있었습니다.
```
---