### PR TITLE
이상화 / 4기 3주차 / 3문제

### DIFF
--- a/sanghwa/BOJ/BOJ1106.java
+++ b/sanghwa/BOJ/BOJ1106.java
@@ -1,0 +1,56 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ1106 {
+
+	static long[] dp;
+	static int[][] cities;
+	static int target;
+	static int COST = 0;
+	static int VALUE = 1;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader buffer = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer token = new StringTokenizer(buffer.readLine());
+
+		target = Integer.parseInt(token.nextToken());
+		int cityNum = Integer.parseInt(token.nextToken());
+		cities = new int[cityNum][2];
+
+		for (int i = 0; i < cityNum; i++) {
+			token = new StringTokenizer(buffer.readLine());
+			int cost = Integer.parseInt(token.nextToken());
+			int value = Integer.parseInt(token.nextToken());
+			cities[i][COST] = cost;
+			cities[i][VALUE] = value;
+		}
+		dp = new long[target + 100];
+		Arrays.fill(dp, Long.MAX_VALUE);
+		dp[0] = 0;
+
+		doDp();
+		long result = Long.MAX_VALUE;
+		for (int i = target; i < dp.length; i++) {
+			result = Math.min(result, dp[i]);
+		}
+		System.out.println(result);
+	}
+
+	static void doDp() {
+		for (int i = 1; i < dp.length; i++) {
+			for (int[] city : cities) {
+				int value = city[VALUE];
+				int cost = city[COST];
+				if (i < value || dp[i - value] == Long.MAX_VALUE) {
+					continue;
+				}
+				dp[i] = Math.min(dp[i], dp[i - value] + cost);
+			}
+		}
+	}
+}

--- a/sanghwa/BOJ/BOJ1443.java
+++ b/sanghwa/BOJ/BOJ1443.java
@@ -1,0 +1,44 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ1443 {
+
+	static int maxTarget;
+	static int operationCnt;
+	static int result = -1;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader buffer = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer token = new StringTokenizer(buffer.readLine());
+
+		int power = Integer.parseInt(token.nextToken());
+		maxTarget = (int)Math.pow(10, power);
+		operationCnt = Integer.parseInt(token.nextToken());
+
+		if (operationCnt == 0) {
+			System.out.println(1);
+			return;
+		}
+
+		backTracking(0, 1, 9);
+		System.out.println(result);
+	}
+
+	static void backTracking(int cnt, int currNum, int maxMultiplier) {
+		if (cnt == operationCnt) {
+			result = Math.max(currNum, result);
+			return;
+		}
+
+		for (int i = maxMultiplier; i >= 2; i--) {
+			long nextNum = (long)currNum * i;
+			if (nextNum >= maxTarget) continue;
+			if (nextNum * Math.pow(9, operationCnt - cnt - 1) <= result) break; // 최선의 결과가 현재 결과보다 작으면 중지
+			backTracking(cnt + 1, (int)nextNum, i); // maxMultiplier값을 다르게 전달하여 4*3, 3*4와 같은 중복연산 방지
+		}
+	}
+}

--- a/sanghwa/BOJ/BOJ14948.java
+++ b/sanghwa/BOJ/BOJ14948.java
@@ -1,0 +1,103 @@
+package BOJ;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ14948 {
+	static int N, M;
+	static int[][] map;
+	static int[][] dirs = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+
+	static class Point {
+		int x, y, maxLevel;
+		boolean usedItem;
+
+		Point(int x, int y, int maxLevel, boolean usedItem) {
+			this.x = x;
+			this.y = y;
+			this.maxLevel = maxLevel;
+			this.usedItem = usedItem;
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		map = new int[N][M];
+
+		int left = 0, right = 0;
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < M; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				right = Math.max(right, map[i][j]);
+			}
+		}
+
+		int result = binarySearch(left, right);
+		System.out.println(result);
+	}
+
+	// 이분탐색
+	static int binarySearch(int left, int right) {
+		int result = right;
+		while (left <= right) {
+			int mid = left + (right - left) / 2;
+			if (canReach(mid)) {
+				result = mid;
+				right = mid - 1;
+			} else {
+				left = mid + 1;
+			}
+		}
+		return result;
+	}
+
+	// 문제생각의 전환: 레벨을 기준으로 도착할 수 있는지 판단한다. BFS
+	static boolean canReach(int level) {
+		Queue<Point> queue = new LinkedList<>();
+		boolean[][][] visited = new boolean[N][M][2];
+		queue.offer(new Point(0, 0, map[0][0], false));
+		visited[0][0][0] = true;
+
+		while (!queue.isEmpty()) {
+			Point cur = queue.poll();
+
+			if (cur.x == N - 1 && cur.y == M - 1) {
+				return true;
+			}
+
+			for (int[] dir : dirs) {
+				int nx = cur.x + dir[0];
+				int ny = cur.y + dir[1];
+
+				if (nx >= 0 && nx < N && ny >= 0 && ny < M) {
+					int newMaxLevel = Math.max(cur.maxLevel, map[nx][ny]);
+					if (newMaxLevel <= level && !visited[nx][ny][cur.usedItem ? 1 : 0]) {
+						queue.offer(new Point(nx, ny, newMaxLevel, cur.usedItem));
+						visited[nx][ny][cur.usedItem ? 1 : 0] = true;
+					}
+				}
+			}
+
+			if (!cur.usedItem) {
+				for (int[] dir : dirs) {
+					int nx = cur.x + dir[0] * 2;
+					int ny = cur.y + dir[1] * 2;
+
+					if (nx >= 0 && nx < N && ny >= 0 && ny < M && !visited[nx][ny][1]) {
+						int newMaxLevel = Math.max(cur.maxLevel, map[nx][ny]);
+						if (newMaxLevel <= level) {
+							queue.offer(new Point(nx, ny, newMaxLevel, true));
+							visited[nx][ny][1] = true;
+						}
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
## 문제명 : ```호텔```
> 시간 복잡도 :  , 공간 복잡도 : 

### 1. 풀이 과정
```
DP, Knapsack 문제였습니다.
dp[인원] = 비용을 의미합니다.
dp[현재인원 - 넣을 인원] + 추가비용, dp[현재인원]을 비교하며 dp 배열을 채웁니다.
```


---


## 문제명 : ``` 군대탈출하기 ```
> 시간 복잡도 :  , 공간 복잡도 : 

### 1. 풀이 과정
```
bfs로 해결하려했으나 성능개선에 문제가 있어 PerPlexity의 도움을 받았습니다.
문제의 접근방식에 전환이 필요했습니다.
레벨을 이분탐색하며 해당레벨에 골인지점에 도달할 수 있는지 BFS로 확인합니다.
최소 레벨을 찾아 결과를 출력합니다.
```
---

## 문제명 : ``` 망가진 계산기 ```
> 시간 복잡도 :  , 공간 복잡도 : 

### 1. 풀이 과정
```
일반적인 백트래킹으로 해결하면 연산이 너무 오래걸렸습니다. Perplexity의 도움으로 최적화했습니다.
1. `if (nextNum >= maxTarget) continue;`
 - 가지치기로 불필요한 연산을 줄입니다.
2. if (nextNum * Math.pow(9, operationCnt - cnt - 1) <= result) break;
- 최적화 추정 기법
- 현재 상태에서 최선의 결과와 현재 최적의해를 비교하여 불필요한 연산을 줄입니다.
3. `backTracking(cnt + 1, (int)nextNum, i); `
- 순열 생성 최적화
- (4 * 3), (3 * 4)와 같은 중복 순열 연산을 회피합니다.
```